### PR TITLE
#170865656 Admin get all announcements from all users api

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["@babel/preset-env"]
+}

--- a/.covaralls.yml
+++ b/.covaralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: ClTf6WvQvB9g97LzMIswSHmjwDKIhSU9q

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,26 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js
+  - 13.6.0
+
+install
+  - npm ci
+
+script
+  - npm test
+
+notification
+  - email: false
+  
+after_success
+  - npm run coverage

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web:npm start

--- a/package.json
+++ b/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "announceit",
+  "version": "1.0.0",
+  "description": "AnnounceIT is a platform which facilitates advertisers to be linked with broadcasting agencies",
+  "main": "server/index.js",
+  "scripts": {
+    "start":"NODE_ENV=production babel-node server/index.js",
+    "dev": "NODE_ENV=dev nodemon --exec babel-node server/index.js",
+    "test": "NODE_ENV=test nyc mocha --exit --require @babel/register --require babel-polyfill ./server/v1/tests/*.test.js",
+    "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test | coveralls"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/descholar-ceo/AnnounceIT.git"
+  },
+  "keywords": [
+    "express",
+    "postgres",
+    "data-structure"
+  ],
+  "author": "descholar",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/descholar-ceo/AnnounceIT/issues"
+  },
+  "homepage": "https://github.com/descholar-ceo/AnnounceIT#readme",
+  "dependencies": {
+    "@babel/cli": "^7.8.3",
+    "@babel/core": "^7.8.3",
+    "@babel/node": "^7.8.3",
+    "@babel/preset-env": "^7.8.3",
+    "@babel/register": "^7.8.3",
+    "babel-loader": "^8.0.6",
+    "babel-node": "0.0.1-security",
+    "babel-polyfill": "^6.26.0",
+    "bcrypt": "^3.0.7",
+    "chai": "^4.2.0",
+    "chai-http": "^4.3.0",
+    "coveralls": "^3.0.9",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1",
+    "jsonwebtoken": "^8.5.1",
+    "nyc": "^15.0.0",
+    "swagger-jsdoc": "^3.5.0",
+    "swagger-ui-express": "^4.1.3"
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0",
+    "eslint-plugin-react": "^7.18.0",
+    "mocha": "^7.0.0",
+    "mocha-lcov-reporter": "^1.3.0",
+    "nodemon": "^2.0.2"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-undef */
+import express from 'express';
+import dotenv from 'dotenv';
+import appGeneralMiddlewares from './v1/middlewares/appGeneralMiddlewares';
+
+dotenv.config();
+
+const server = express();
+const port = process.env.PORT;
+
+appGeneralMiddlewares(server, express);
+
+server.listen(port, () => {
+  console.log(`listening to port ${port}`);
+});
+
+export default server;

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-undef */
+import express from 'express';
+import dotenv from 'dotenv';
+import appGeneralMiddlewares from './v1/middlewares/appGeneralMiddlewares';
+
+dotenv.config();
+
+const server = express();
+const port = process.env.PORT;
+
+appGeneralMiddlewares(server, express);
+
+server.listen(port, () => {
+  //console.log(`listening to port ${port}`);
+});
+
+export default server;

--- a/server/v1/helpers/handleTokens.js
+++ b/server/v1/helpers/handleTokens.js
@@ -1,0 +1,6 @@
+/* eslint-disable no-undef */
+import jwt from 'jsonwebtoken';
+
+export const generateToken = (userInfo) => {
+    return jwt.sign(userInfo, process.env.TOKEN_KEY,{expiresIn:'6h'});
+}

--- a/server/v1/helpers/passwordEncryption.js
+++ b/server/v1/helpers/passwordEncryption.js
@@ -1,0 +1,9 @@
+import bcrypt from 'bcrypt';
+
+export const hashPassword = (password) => {
+    const saltRounds = bcrypt.genSaltSync(14);
+  return bcrypt.hashSync(password, saltRounds);
+}
+
+export const checkPassword = (currPassword, savedPassword) =>
+  (bcrypt.compareSync(currPassword, savedPassword));

--- a/server/v1/helpers/passwordEncryption.js
+++ b/server/v1/helpers/passwordEncryption.js
@@ -1,0 +1,8 @@
+import bcrypt from 'bcrypt';
+
+export const hashPassword = (password) => {
+    const saltRounds = bcrypt.genSaltSync(14);
+  return bcrypt.hashSync(password, saltRounds);
+}
+
+export const checkPassword = (currPassword, savedPassword) => bcrypt.compareSync(currPassword, savedPassword);

--- a/server/v1/middlewares/appGeneralMiddlewares.js
+++ b/server/v1/middlewares/appGeneralMiddlewares.js
@@ -9,6 +9,7 @@ const appGeneralMiddlewares = (server, express) => {
 
   server.use(express.json());
   server.use('/api/v1/auth', routes.userRouter);
+  server.use('/api/v1/announcements', routes.announcementRouter);
 };
 
 export default appGeneralMiddlewares;

--- a/server/v1/middlewares/appGeneralMiddlewares.js
+++ b/server/v1/middlewares/appGeneralMiddlewares.js
@@ -1,0 +1,14 @@
+/**
+ * THIS FILE IS TO SUMMARIZE ALL OF MIDDLEWARES IN ONE MODULE AND THEN
+ * USE THEM IN index.js MODULE
+ *
+ */
+import routes from '../routes';
+
+const appGeneralMiddlewares = (server, express) => {
+
+  server.use(express.json());
+  server.use('/api/v1/auth', routes.userRouter);
+};
+
+export default appGeneralMiddlewares;

--- a/server/v1/middlewares/authentication/authenticate.js
+++ b/server/v1/middlewares/authentication/authenticate.js
@@ -7,7 +7,7 @@ export const authenticate = (req, res, next) => {
     if (process.env.NODE_ENV === 'test') {
         token = req.query.auth;
     } else {
-        req.headers.authorization.split(' ')[1];
+        token = req.headers.authorization.split(' ')[1];
     }
 
     try {

--- a/server/v1/middlewares/authentication/authenticate.js
+++ b/server/v1/middlewares/authentication/authenticate.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-undef */
+import jwt from 'jsonwebtoken';
+
+export const authenticate = (req, res, next) => {
+    let token;
+
+    if (process.env.NODE_ENV === 'test') {
+        token = req.query.auth;
+    } else {
+        req.headers.authorization.split(' ')[1];
+    }
+
+    try {
+        const decodedToken = jwt.decode(token, process.env.TOKEN_KEY);
+        req.authenticatedUser = decodedToken;
+        next();
+    } catch (err) {
+        res.status(401).send({
+            status: 'error',
+            error:'You are not authorized to access the resources, you were trying, login first or signup'
+        })
+    }
+}

--- a/server/v1/middlewares/validations/validateAnnouncementData.js
+++ b/server/v1/middlewares/validations/validateAnnouncementData.js
@@ -1,0 +1,14 @@
+import user from '../../models/entities/user';
+
+export const validateAnnouncementData = (req, res, next) => {
+    const { owner } = req.body;
+    const announcOwner = user.users.data.find((foundOwn) => foundOwn.id === owner);
+    if (announcOwner) {
+        next();
+    } else {
+        res.status(400).send({
+            status: "error",
+            error: "The user you are trying to use is not exists"
+        })
+    }
+}

--- a/server/v1/middlewares/validations/validateAnnouncementData.js
+++ b/server/v1/middlewares/validations/validateAnnouncementData.js
@@ -1,10 +1,28 @@
 import user from '../../models/entities/user';
 
 export const validateAnnouncementData = (req, res, next) => {
-    const { owner } = req.body;
+    const { owner,text,startdate,enddate } = req.body;
     const announcOwner = user.users.data.find((foundOwn) => foundOwn.id === owner);
     if (announcOwner) {
-        next();
+        if (text) {
+            if (startdate) {
+                if (enddate) {
+                    next();
+                } else {
+                    res.status(400).send({status:'error',error:"Enter the end date of your announcement"})
+                }
+            } else {
+                res.status(400).send({
+                    status: 'error',
+                    error:'Select the starting date of your announcement'
+                })
+            }
+        } else {
+            res.status(400).send({
+                status:'error',
+                error:'Enter the body of your annnouncement'
+            })
+        }
     } else {
         res.status(400).send({
             status: "error",

--- a/server/v1/middlewares/validations/validateLoginData.js
+++ b/server/v1/middlewares/validations/validateLoginData.js
@@ -1,0 +1,26 @@
+export const validateLoginData = (req, res, next) => {
+    const { email, password } = req.body;
+
+    if (email) {
+        if (email.includes('@')) {
+            if (password) {
+                next();
+            } else {
+                res.status(400).send({
+                    status: 'error',
+                    error:'Enter your password please!',
+                })
+            }
+        } else {
+            res.status(400).send({
+                status: 'error',
+                error:'You entered something other than email!'
+            })
+        }
+    } else {
+        res.status(400).send({
+            status: 'error',
+            error:'Enter your email to login please'
+        })
+    }
+}

--- a/server/v1/middlewares/validations/validateSignupData.js
+++ b/server/v1/middlewares/validations/validateSignupData.js
@@ -1,0 +1,45 @@
+import user from '../../models/entities/user';
+
+export const validateUserData = (req, res, next) => {
+    const {
+        fname, lname, email, phonenumber, address, password
+    } = req.body;
+    
+    //checking if the email a user sent does exists
+    let registeredEmails = []; 
+    
+    user.users.data.forEach((currUser) => {
+        registeredEmails.push(currUser.email);
+    })
+
+    //validate data
+    if (fname) {
+        if (lname) {
+            if (email && email.includes('@')) {
+                if (!registeredEmails.includes(email)) {
+                    if (phonenumber) {
+                    if (address) {
+                        if (password) {
+                            next();
+                        } else {
+                            res.status(400).send({status:'error',error:'Enter a password you prefer to use!'})
+                        }
+                    } else {
+                        res.status(400).send({status:'error',error:'Enter your address'})
+                    }
+                } else {
+                    res.status(400).send({status:'error',error:'Enter your phone number'})
+                }
+                } else {
+                    res.status(400).send({status:'error',error:'The email you put is already used!'})
+               }
+            } else {
+                res.status(400).send({status:'error',error:'Enter a valid email'})
+            }
+        } else {
+            res.status(400).send({status:'error',error:'Enter your last name'})
+        }
+    } else {
+        res.status(400).send({status:'error',error:'Enter your first name'});
+    }
+}

--- a/server/v1/models/announcementModels.js
+++ b/server/v1/models/announcementModels.js
@@ -12,3 +12,27 @@ export const addNewAnnouncement = (req, res, next) => {
     
     next();
 }
+
+export const getAllAnnouncementsByOwnerId = (req, res, next) => {
+    const { authenticatedUser } = req;
+    const allMyAnnouncs = announcemment.announcements.getAllAnnouncementsByOwnerId(authenticatedUser.id);
+    
+    if (allMyAnnouncs) {
+        if (allMyAnnouncs.length !== 0) {
+            res.status(200).json({
+                status: 'success',
+                data: allMyAnnouncs
+            });
+            next();
+        } else {
+            res.status(200).send({
+                status: 'success',
+                data:['It seems that you don\'t have any recorded announcement yet']
+            })
+        }
+    } else {
+        res.status(401).send({
+            error:'The announcements you are requesting for, are not found, try again!'
+        })
+    }
+}

--- a/server/v1/models/announcementModels.js
+++ b/server/v1/models/announcementModels.js
@@ -57,3 +57,24 @@ export const getSpecificAnnouncement = (req, res, next) => {
         })
     }
 }
+
+export const getSpecificAnnouncementByStatus = (req, res, next) => {
+    const { authenticatedUser } = req;
+    const {announcementStatus} = req.params;
+
+    const gottenAnnounc = announcemment.announcements
+        .getSpecificAnnouncementByStatus(announcementStatus, authenticatedUser.id);
+    
+    if (gottenAnnounc) {
+        res.status(200).json({
+            status: 'success',
+            data: gottenAnnounc
+        });
+        next();
+    } else {
+        res.status(404).send({
+            status: 'error',
+            error: 'The announcement you trying to get is not registered yet'
+        })
+    }
+}

--- a/server/v1/models/announcementModels.js
+++ b/server/v1/models/announcementModels.js
@@ -31,8 +31,29 @@ export const getAllAnnouncementsByOwnerId = (req, res, next) => {
             })
         }
     } else {
-        res.status(401).send({
+        res.status(404).send({
             error:'The announcements you are requesting for, are not found, try again!'
+        })
+    }
+}
+
+export const getSpecificAnnouncement = (req, res, next) => {
+    const { authenticatedUser } = req;
+    const {announcementId} = req.params;
+
+    const gottenAnnounc = announcemment.announcements.getSpecificAnnouncementById(announcementId,
+        authenticatedUser.id);
+    
+    if (gottenAnnounc) {
+        res.status(200).json({
+            status: 'success',
+            data: gottenAnnounc
+        });
+        next();
+    } else {
+        res.status(404).send({
+            status: 'error',
+            error: 'The announcement you trying to get is not registered yet'
         })
     }
 }

--- a/server/v1/models/announcementModels.js
+++ b/server/v1/models/announcementModels.js
@@ -78,3 +78,36 @@ export const getSpecificAnnouncementByStatus = (req, res, next) => {
         })
     }
 }
+
+export const adminGetAllAnnouncements = (req, res, next) => {
+    const { authenticatedUser } = req;
+    if (authenticatedUser.isadmin) {
+        const allAnnouncs = announcemment.announcements.adminGetAllAnnouncements();
+
+        if (allAnnouncs) {
+            if (allAnnouncs.length !== 0) {
+                res.status(200).send({
+            status: 'success',
+            data: allAnnouncs
+        });
+        next();
+            } else {
+                res.status(404).send({
+                    status: 'error',
+                    error:'It seems like no one has posted any announcement yet!'
+                })
+            }
+        } else {
+            res.status(500).send({
+                status: 'error',
+                error:'Unexpected cirmuctance occured in our servers, please refresh'
+            })
+        }
+        
+    } else {
+        res.status(401).send({
+            status:'error',
+            error: 'You are not admin'
+        })
+    }
+}

--- a/server/v1/models/announcementModels.js
+++ b/server/v1/models/announcementModels.js
@@ -1,0 +1,14 @@
+import announcemment from '../models/entities/announcement'
+
+export const addNewAnnouncement = (req, res, next) => {
+    const newAnnouncId = announcemment.announcements.announcArray.length + 1;
+    const announcToSave = new announcemment.AnnouncementData(req.body, newAnnouncId);
+    const savedAnnounceme = announcemment.announcements.addNewAnnouncement(announcToSave);
+
+    res.status(201).json({
+        status: 'success',
+        data:savedAnnounceme
+    });
+    
+    next();
+}

--- a/server/v1/models/entities/announcement.js
+++ b/server/v1/models/entities/announcement.js
@@ -17,6 +17,12 @@ class Announcements{
         })
         return foundAnnouncA;
     }
+
+    getSpecificAnnouncementById(announcID, userID) {
+        return this.announcArray.find((currAnn) => parseInt(currAnn.announcementowner) === parseInt(userID)
+            && parseInt(currAnn.announcementid) === parseInt(announcID));
+    }
+    
 }
 
 class AnnouncementData{

--- a/server/v1/models/entities/announcement.js
+++ b/server/v1/models/entities/announcement.js
@@ -1,0 +1,24 @@
+class Announcements{
+    constructor() {
+        this.announcArray = [];
+    }
+
+    addNewAnnouncement(announcement) {
+        this.announcArray.push(announcement);
+        return this.announcArray.find((announc) => announc.id === announcement.id);
+    }
+}
+
+class AnnouncementData{
+    constructor(announcData, id) {
+        this.announcementid = id;
+        this.announcementowner = announcData.owner;
+        this.announcementstatus = announcData.status;
+        this.annoucemmenttext = announcData.text;
+        this.announcementstartdate = announcData.startdate;
+        this.announcementsenddate = announcData.enddate;
+    }
+}
+
+const announcements = new Announcements();
+export default {announcements,AnnouncementData}

--- a/server/v1/models/entities/announcement.js
+++ b/server/v1/models/entities/announcement.js
@@ -7,6 +7,16 @@ class Announcements{
         this.announcArray.push(announcement);
         return this.announcArray.find((announc) => announc.id === announcement.id);
     }
+
+    getAllAnnouncementsByOwnerId(owner) {
+        let foundAnnouncA=[];
+        this.announcArray.forEach((currAnn) => {
+            if (currAnn.announcementowner === owner) {
+                foundAnnouncA.push(currAnn);
+            }
+        })
+        return foundAnnouncA;
+    }
 }
 
 class AnnouncementData{

--- a/server/v1/models/entities/announcement.js
+++ b/server/v1/models/entities/announcement.js
@@ -3,11 +3,13 @@ class Announcements{
         this.announcArray = [];
     }
 
+    // adding new
     addNewAnnouncement(announcement) {
         this.announcArray.push(announcement);
         return this.announcArray.find((announc) => announc.id === announcement.id);
     }
 
+    // all for a currently logged in user
     getAllAnnouncementsByOwnerId(owner) {
         let foundAnnouncA=[];
         this.announcArray.forEach((currAnn) => {
@@ -18,10 +20,13 @@ class Announcements{
         return foundAnnouncA;
     }
 
+    // by id
     getSpecificAnnouncementById(announcID, userID) {
         return this.announcArray.find((currAnn) => parseInt(currAnn.announcementowner) === parseInt(userID)
             && parseInt(currAnn.announcementid) === parseInt(announcID));
     }
+
+    // by status
     getSpecificAnnouncementByStatus(announcStatus, userID) {
         let newArr = [];
         this.announcArray.forEach((currAnn) => {
@@ -29,10 +34,14 @@ class Announcements{
                 newArr.push(currAnn);
             }
         });
-
         return newArr;
-
     }
+
+    // admin get all
+    adminGetAllAnnouncements(){
+        return this.announcArray;
+    }
+
     
 }
 

--- a/server/v1/models/entities/announcement.js
+++ b/server/v1/models/entities/announcement.js
@@ -22,6 +22,17 @@ class Announcements{
         return this.announcArray.find((currAnn) => parseInt(currAnn.announcementowner) === parseInt(userID)
             && parseInt(currAnn.announcementid) === parseInt(announcID));
     }
+    getSpecificAnnouncementByStatus(announcStatus, userID) {
+        let newArr = [];
+        this.announcArray.forEach((currAnn) => {
+            if (currAnn.announcementstatus === announcStatus && parseInt(currAnn.announcementowner) === parseInt(userID)) {
+                newArr.push(currAnn);
+            }
+        });
+
+        return newArr;
+
+    }
     
 }
 

--- a/server/v1/models/entities/user.js
+++ b/server/v1/models/entities/user.js
@@ -6,11 +6,20 @@ class User{
         this.data = [
             {
                 "id":"1",
-                fname: 'emmamugira',
+                fname: 'nezago',
                 lname: 'emma',
                 password: hashPassword('123'),
-                email:'emmamugira@gmail.com'
-            }
+                email: 'emmamugira@gmail.com',
+                isadmin:true
+            },
+            {
+                "id":"2",
+                fname: 'descholar',
+                lname: 'emma',
+                password: hashPassword('123'),
+                email: 'descholar.stech@gmail.com',
+                isadmin:false
+            },
         ];
     }
 

--- a/server/v1/models/entities/user.js
+++ b/server/v1/models/entities/user.js
@@ -1,0 +1,28 @@
+import { hashPassword } from '../../helpers/passwordEncryption';
+
+class User{
+    constructor() {
+        this.data = [];
+    }
+
+    //function to save new user
+    saveUser(user){
+        this.data.push(user);
+        return this.data.find((dat) => (dat.email === user.email));
+    }
+}
+
+class UsersData{
+    constructor(data,id) {
+        this.id = id;
+        this.email = data.email;
+        this.fname = data.fname;
+        this.lname = data.lname;
+        this.password = hashPassword(data.password);
+        this.phonenumber = data.phonenumber;
+        this.address = data.address;
+        this.isadmin = data.isadmin;
+    }
+}
+const users = new User;
+export default { users, UsersData};

--- a/server/v1/models/entities/user.js
+++ b/server/v1/models/entities/user.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-undef */
+import { hashPassword } from '../../helpers/passwordEncryption';
+
+class User{
+    constructor() {
+        this.data = [
+            {
+                fname: 'emmamugira',
+                lname: 'emma',
+                password: hashPassword('123'),
+                email:'emmamugira@gmail.com'
+            }
+        ];
+    }
+
+    //function to save new user
+    saveUser(user){
+        this.data.push(user);
+        return this.data.find((dat) => (dat.email === user.email));
+    }
+
+    // fnction to get a user by email
+    getUserByEmail(email) {
+        return this.data.find((dat) => (dat.email === email));
+    }
+}
+
+class UsersData{
+    constructor(data,id) {
+        this.id = id;
+        this.email = data.email;
+        this.fname = data.fname;
+        this.lname = data.lname;
+        this.password = hashPassword(data.password);
+        this.phonenumber = data.phonenumber;
+        this.address = data.address;
+        this.isadmin = data.isadmin;
+    }
+}
+const users = new User;
+export default { users, UsersData};

--- a/server/v1/models/entities/user.js
+++ b/server/v1/models/entities/user.js
@@ -5,6 +5,7 @@ class User{
     constructor() {
         this.data = [
             {
+                "id":"1",
                 fname: 'emmamugira',
                 lname: 'emma',
                 password: hashPassword('123'),
@@ -37,5 +38,5 @@ class UsersData{
         this.isadmin = data.isadmin;
     }
 }
-const users = new User;
+const users = new User();
 export default { users, UsersData};

--- a/server/v1/models/index.js
+++ b/server/v1/models/index.js
@@ -1,4 +1,12 @@
 import { addUser, getUser } from '../models/userModels';
-import { addNewAnnouncement } from '../models/announcementModels';
+import {
+    addNewAnnouncement,
+    getAllAnnouncementsByOwnerId
+} from '../models/announcementModels';
 
-export default { addUser,getUser,addNewAnnouncement };
+export default {
+    addUser,
+    getUser,
+    addNewAnnouncement,
+    getAllAnnouncementsByOwnerId
+};

--- a/server/v1/models/index.js
+++ b/server/v1/models/index.js
@@ -1,3 +1,4 @@
-import { addUser,getUser } from '../models/userModels';
+import { addUser, getUser } from '../models/userModels';
+import { addNewAnnouncement } from '../models/announcementModels';
 
-export default { addUser,getUser };
+export default { addUser,getUser,addNewAnnouncement };

--- a/server/v1/models/index.js
+++ b/server/v1/models/index.js
@@ -1,12 +1,14 @@
 import { addUser, getUser } from '../models/userModels';
 import {
     addNewAnnouncement,
-    getAllAnnouncementsByOwnerId
+    getAllAnnouncementsByOwnerId,
+    getSpecificAnnouncement
 } from '../models/announcementModels';
 
 export default {
     addUser,
     getUser,
     addNewAnnouncement,
-    getAllAnnouncementsByOwnerId
+    getAllAnnouncementsByOwnerId,
+    getSpecificAnnouncement
 };

--- a/server/v1/models/index.js
+++ b/server/v1/models/index.js
@@ -1,0 +1,3 @@
+import { addUser,getUser } from '../models/userModels';
+
+export default { addUser,getUser };

--- a/server/v1/models/index.js
+++ b/server/v1/models/index.js
@@ -4,6 +4,7 @@ import {
     getAllAnnouncementsByOwnerId,
     getSpecificAnnouncement,
     getSpecificAnnouncementByStatus,
+    adminGetAllAnnouncements
 } from '../models/announcementModels';
 
 export default {
@@ -12,5 +13,6 @@ export default {
     addNewAnnouncement,
     getAllAnnouncementsByOwnerId,
     getSpecificAnnouncement,
-    getSpecificAnnouncementByStatus
+    getSpecificAnnouncementByStatus,
+    adminGetAllAnnouncements,
 };

--- a/server/v1/models/index.js
+++ b/server/v1/models/index.js
@@ -1,0 +1,3 @@
+import { addUser } from '../models/userModels';
+
+export default { addUser };

--- a/server/v1/models/index.js
+++ b/server/v1/models/index.js
@@ -2,7 +2,8 @@ import { addUser, getUser } from '../models/userModels';
 import {
     addNewAnnouncement,
     getAllAnnouncementsByOwnerId,
-    getSpecificAnnouncement
+    getSpecificAnnouncement,
+    getSpecificAnnouncementByStatus,
 } from '../models/announcementModels';
 
 export default {
@@ -10,5 +11,6 @@ export default {
     getUser,
     addNewAnnouncement,
     getAllAnnouncementsByOwnerId,
-    getSpecificAnnouncement
+    getSpecificAnnouncement,
+    getSpecificAnnouncementByStatus
 };

--- a/server/v1/models/userModels.js
+++ b/server/v1/models/userModels.js
@@ -1,0 +1,29 @@
+import user from './entities/user';
+import { generateToken } from '../helpers/handleTokens';
+
+export const addUser = (req, res, next) => {
+    const newId = user.users.data.length + 1;
+    const newDataToSave = new user.UsersData(req.body, newId);
+    const registeredUser = user.users.saveUser(newDataToSave);
+    const id = registeredUser.id;
+    const fname = registeredUser.fname;
+    const lname = registeredUser.lname;
+    const email = registeredUser.email;
+    const phonenumber = registeredUser.phonenumber;
+    const address = registeredUser.address;
+    const isadmin = registeredUser.isadmin;
+    const dataToSendToFrontend = {id, fname, lname, email, phonenumber, address,isadmin}
+    const gotenToken = generateToken(dataToSendToFrontend);
+
+    res.status(201).json({
+        status: 'success',
+        data: {
+            token:gotenToken,
+            first_name: fname,
+            last_name: lname,
+            email
+        }
+    });
+    next();
+    
+}

--- a/server/v1/models/userModels.js
+++ b/server/v1/models/userModels.js
@@ -1,0 +1,71 @@
+import user from './entities/user';
+import { generateToken } from '../helpers/handleTokens';
+import { checkPassword } from '../helpers/passwordEncryption';
+
+// signup
+export const addUser = (req, res, next) => {
+    const newId = user.users.data.length + 1;
+    const newDataToSave = new user.UsersData(req.body, newId);
+    const registeredUser = user.users.saveUser(newDataToSave);
+    const id = registeredUser.id;
+    const fname = registeredUser.fname;
+    const lname = registeredUser.lname;
+    const email = registeredUser.email;
+    const phonenumber = registeredUser.phonenumber;
+    const address = registeredUser.address;
+    const isadmin = registeredUser.isadmin;
+    const dataToSendToFrontend = {id, fname, lname, email, phonenumber, address,isadmin}
+    const gotenToken = generateToken(dataToSendToFrontend);
+
+    res.status(201).json({
+        status: 'success',
+        data: {
+            token:gotenToken,
+            first_name: fname,
+            last_name: lname,
+            email
+        }
+    });
+    next();   
+}
+
+// signin
+export const getUser = (req, res, next) => {
+    const { email, password } = req.body;
+    const gottenUser = user.users.getUserByEmail(email);
+    if (gottenUser) {
+        
+        if (checkPassword(password, gottenUser.password)) {
+            const id = gottenUser.id;
+            const fname = gottenUser.fname;
+            const lname = gottenUser.lname;
+            const email = gottenUser.email;
+            const phonenumber = gottenUser.phonenumber;
+            const address = gottenUser.address;
+            const isadmin = gottenUser.isadmin;
+            const dataToSendToFrontend = {id, fname, lname, email, phonenumber, address,isadmin}
+            const gotenToken = generateToken(dataToSendToFrontend); 
+
+            res.status(200).json({
+                status: 'success',
+                data: {
+                    token:gotenToken,
+                    first_name: fname,
+                    last_name: lname,
+                    email
+                }});
+                next();   
+        } else {
+            res.status(403).json({
+                status: 'error',
+                data: `You are not allowed to login, entered a wrong password!`
+            })
+        }
+    } else {
+        res.status(403).json({
+            status: 'error',
+            data: `You are not allowed to login, because we don't recognize ${email}
+             on AnnounceIT servers, so Signup first!`
+        });
+    }
+}

--- a/server/v1/routes/api/announcement-routes.js
+++ b/server/v1/routes/api/announcement-routes.js
@@ -8,5 +8,7 @@ const announcementRouter = new Router();
 announcementRouter.post('/create-announcement', validateAnnouncementData ,models.addNewAnnouncement);
 announcementRouter.get('/get-all-announcement-for-current-user',
     authenticate, models.getAllAnnouncementsByOwnerId);
+announcementRouter.get('/get-specific-announcement/:announcementId',
+    authenticate, models.getSpecificAnnouncement);
 
 export default announcementRouter;

--- a/server/v1/routes/api/announcement-routes.js
+++ b/server/v1/routes/api/announcement-routes.js
@@ -10,5 +10,7 @@ announcementRouter.get('/get-all-announcement-for-current-user',
     authenticate, models.getAllAnnouncementsByOwnerId);
 announcementRouter.get('/get-specific-announcement/:announcementId',
     authenticate, models.getSpecificAnnouncement);
+announcementRouter.get('/get-specific-announcement-by-status/:announcementStatus',
+    authenticate, models.getSpecificAnnouncementByStatus);
 
 export default announcementRouter;

--- a/server/v1/routes/api/announcement-routes.js
+++ b/server/v1/routes/api/announcement-routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import models from '../../models'
+import { validateAnnouncementData } from '../../middlewares/validations/validateAnnouncementData';
+
+const announcementRouter = new Router();
+
+announcementRouter.post('/create-announcement', validateAnnouncementData ,models.addNewAnnouncement);
+
+export default announcementRouter;

--- a/server/v1/routes/api/announcement-routes.js
+++ b/server/v1/routes/api/announcement-routes.js
@@ -1,9 +1,12 @@
 import { Router } from 'express';
+import {  authenticate } from '../../middlewares/authentication/authenticate';
 import models from '../../models'
 import { validateAnnouncementData } from '../../middlewares/validations/validateAnnouncementData';
 
 const announcementRouter = new Router();
 
 announcementRouter.post('/create-announcement', validateAnnouncementData ,models.addNewAnnouncement);
+announcementRouter.get('/get-all-announcement-for-current-user',
+    authenticate, models.getAllAnnouncementsByOwnerId);
 
 export default announcementRouter;

--- a/server/v1/routes/api/announcement-routes.js
+++ b/server/v1/routes/api/announcement-routes.js
@@ -12,5 +12,7 @@ announcementRouter.get('/get-specific-announcement/:announcementId',
     authenticate, models.getSpecificAnnouncement);
 announcementRouter.get('/get-specific-announcement-by-status/:announcementStatus',
     authenticate, models.getSpecificAnnouncementByStatus);
+announcementRouter.get('/admin-get-all-announcements-from-all-users',
+    authenticate, models.adminGetAllAnnouncements);
 
 export default announcementRouter;

--- a/server/v1/routes/api/user-routes.js
+++ b/server/v1/routes/api/user-routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import models from '../../models';
+import { validateUserData } from '../../middlewares/validations/validateSignupData';
+import { validateLoginData } from '../../middlewares/validations/validateLoginData';
+
+const userRouter = new Router();
+
+userRouter.post('/signup', validateUserData, models.addUser);
+userRouter.post('/signin', validateLoginData, models.getUser);
+
+export default userRouter;

--- a/server/v1/routes/api/user-routes.js
+++ b/server/v1/routes/api/user-routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import models from '../../models';
+import { validateUserData } from '../../middlewares/validations/validateSignupData';
+
+const userRouter = new Router();
+
+userRouter.post('/signup', validateUserData, models.addUser);
+
+export default userRouter;

--- a/server/v1/routes/index.js
+++ b/server/v1/routes/index.js
@@ -1,3 +1,4 @@
 import userRouter from './api/user-routes';
+import announcementRouter from './api/announcement-routes';
 
-export default { userRouter };
+export default { userRouter ,announcementRouter};

--- a/server/v1/routes/index.js
+++ b/server/v1/routes/index.js
@@ -1,0 +1,3 @@
+import userRouter from './api/user-routes';
+
+export default { userRouter };

--- a/server/v1/tests/dataToUseInTest.js
+++ b/server/v1/tests/dataToUseInTest.js
@@ -40,6 +40,7 @@ export default {
             "text": "buying computers",
             "start-date": "1/1/2020",
             "end-date": "22/2/2020"
-}
-    }
+        }
+    },
+    fakeToken:'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTEDIyfQ.SlKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
 }

--- a/server/v1/tests/dataToUseInTest.js
+++ b/server/v1/tests/dataToUseInTest.js
@@ -1,0 +1,29 @@
+export default {
+    userTest: {
+        expectedDataForSignup: {
+            "fname":"Minani",
+            "lname":"Emmanuel",
+            "email": "cool@gmail.com",
+            "phonenumber": "0782229462",
+            "isadmin": "true",
+            "address": "kigali",
+            "password": "123"
+        },
+        wrongDataForSignup: {
+            fname: 'Doe',
+            lname: 'John',
+            password: 'johndoe',
+            isadmin:true
+        },
+        expectedDataForLogin: {
+            "email": "emmamugira@gmail.com",
+            "password": "123"
+        },
+        wrongDataForLogin: {
+            "email": "emmamugira@gmail.com",
+        },
+        loginNoEmail: {
+            "password": "123",
+        }
+    }
+}

--- a/server/v1/tests/dataToUseInTest.js
+++ b/server/v1/tests/dataToUseInTest.js
@@ -25,5 +25,21 @@ export default {
         loginNoEmail: {
             "password": "123",
         }
+    },
+    announcementTest: {
+        announcementRegisterExpectedData: {
+            "owner":"1",
+            "status":"active",
+            "text":"buying computers",
+            "startdate":"1/1/2020",
+            "enddate":"22/2/2020"
+        },
+        announcementRegisterWrongData: {
+            "owner": "2",
+            "status": "active",
+            "text": "buying computers",
+            "start-date": "1/1/2020",
+            "end-date": "22/2/2020"
+}
     }
 }

--- a/server/v1/tests/dataToUseInTest.js
+++ b/server/v1/tests/dataToUseInTest.js
@@ -13,10 +13,13 @@ export default {
             fname: 'Doe',
             lname: 'John',
             password: 'johndoe',
-            isadmin:true
         },
         expectedDataForLogin: {
             "email": "emmamugira@gmail.com",
+            "password": "123"
+        },
+        expectedDataForLoginNotAdmin: {
+            "email": "descholar.stech@gmail.com",
             "password": "123"
         },
         wrongDataForLogin: {
@@ -35,12 +38,9 @@ export default {
             "enddate":"22/2/2020"
         },
         announcementRegisterWrongData: {
-            "owner": "2",
-            "status": "active",
-            "text": "buying computers",
-            "start-date": "1/1/2020",
-            "end-date": "22/2/2020"
-        }
+            "owner": "10000000000000",
+            status:'active'
+        },
     },
     fakeToken:'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTEDIyfQ.SlKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
 }

--- a/server/v1/tests/dataToUseInTest.js
+++ b/server/v1/tests/dataToUseInTest.js
@@ -1,0 +1,19 @@
+export default {
+    userTest: {
+        expectedData: {
+            "fname":"Minani",
+            "lname":"Emmanuel",
+            "email": "cool@gmail.com",
+            "phonenumber": "0782229462",
+            "isadmin": "true",
+            "address": "kigali",
+            "password": "123"
+        },
+        wrongData: {
+            fname: 'Doe',
+            lname: 'John',
+            password: 'johndoe',
+            isadmin:true
+        }
+    }
+}

--- a/server/v1/tests/user.test.js
+++ b/server/v1/tests/user.test.js
@@ -162,7 +162,7 @@ describe('Announcements', () => {
             });
     });
 
-    // requesting all announcement with valid token
+    // requesting specic announcement with valid token
     it('Should return object with 200 status, containing properties status and data', (done) => { 
         chai.request(server)
             .get(`/api/v1/announcements/get-specific-announcement/1?auth=${token}`)
@@ -202,6 +202,37 @@ describe('Announcements', () => {
                 expect(res.body).to.be.an('object');
                 expect(res.body).to.have.property('status');
                 expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+
+    // requesting a specific announcement by status with invalid token
+    it('Should return an error with 401 status, and an object containing properties status and error', (done) => { 
+        chai.request(server)
+            .get(`/api/v1/announcements/get-specific-announcement-by-status/pending?auth=${data.fakeToken}`)
+            .set('Accept', 'Application/json')
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(401);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+
+
+    // requesting specific announcement with valid token
+    it('Should return object with 200 status, containing properties status and data', (done) => { 
+        chai.request(server)
+            .get(`/api/v1/announcements/get-specific-announcement-by-status/pending?auth=${token}`)
+            .set('Accept', 'Application/json')
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('data');
                 done();
             });
     });

--- a/server/v1/tests/user.test.js
+++ b/server/v1/tests/user.test.js
@@ -88,3 +88,35 @@ describe('Authentication', () => {
             });
     });
 });
+
+// ANNOUNCEMENTS
+describe('Announcements', () => {
+    it('Should return object with 201 status, containing properties', (done) => { 
+        chai.request(server)
+            .post('/api/v1/announcements/create-announcement')
+            .set('Accept', 'Application/json')
+            .send(data.announcementTest.announcementRegisterExpectedData)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(201);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('data');
+                done();
+            });
+    });
+    it('Should return object with 201 status, containing properties', (done) => { 
+        chai.request(server)
+            .post('/api/v1/announcements/create-announcement')
+            .set('Accept', 'Application/json')
+            .send(data.announcementTest.announcementRegisterWrongData)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(400);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+});

--- a/server/v1/tests/user.test.js
+++ b/server/v1/tests/user.test.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../../index';
+import data from './dataToUseInTest';
+
+chai.use(chaiHttp);
+const expect = chai.expect;
+
+describe('Authentication', () => {
+
+    // user signup
+    it('Should return an object with status code 201 and an object containing  contains token and user data', (done) => {
+        chai.request(server)
+            .post('/api/v1/auth/signup')
+            .set('Accept', 'Application/json')
+            .send(data.userTest.expectedData)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(201);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('data');
+                done();
+            });
+    });
+
+    it('Should return an object with status code 400, and a message', (done) => {
+        chai.request(server)
+            .post('/api/v1/auth/signup')
+            .set('Accept', 'Application/json')
+            .send(data.userTest.wrongData)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(400);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+        })
+    });
+});

--- a/server/v1/tests/user.test.js
+++ b/server/v1/tests/user.test.js
@@ -162,4 +162,48 @@ describe('Announcements', () => {
             });
     });
 
+    // requesting all announcement with valid token
+    it('Should return object with 200 status, containing properties status and data', (done) => { 
+        chai.request(server)
+            .get(`/api/v1/announcements/get-specific-announcement/1?auth=${token}`)
+            .set('Accept', 'Application/json')
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('data');
+                done();
+            });
+    });
+
+    // requesting a specific announcement with invalid token
+    it('Should return an error with 401 status, and an object containing properties status and error', (done) => { 
+        chai.request(server)
+            .get(`/api/v1/announcements/get-specific-announcement/1?auth=${data.fakeToken}`)
+            .set('Accept', 'Application/json')
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(401);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+    // requesting a specific announcement with invalid token
+    it('Should return an error with 404 status, and an object containing properties status and error', (done) => { 
+        chai.request(server)
+            .get(`/api/v1/announcements/get-specific-announcement/0?auth=${token}`)
+            .set('Accept', 'Application/json')
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(404);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+
 });

--- a/server/v1/tests/user.test.js
+++ b/server/v1/tests/user.test.js
@@ -1,0 +1,90 @@
+/* eslint-disable no-undef */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../../index';
+import data from './dataToUseInTest';
+
+chai.use(chaiHttp);
+const expect = chai.expect;
+
+describe('Authentication', () => {
+
+    // user signup
+    it('Should return an object with status code 201 and an object containing  contains token and user data', (done) => {
+        chai.request(server)
+            .post('/api/v1/auth/signup')
+            .set('Accept', 'Application/json')
+            .send(data.userTest.expectedDataForSignup)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(201);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('data');
+                done();
+            });
+    });
+
+    it('Should return an object with status code 400, and a message', (done) => {
+        chai.request(server)
+            .post('/api/v1/auth/signup')
+            .set('Accept', 'Application/json')
+            .send(data.userTest.wrongDataForSignup)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(400);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+
+    // for signin
+    it('Should return an object with status code 200 and an object which contains token and user data', (done) => {
+        chai.request(server)
+            .post('/api/v1/auth/signin')
+            .set('Accept', 'Application/json')
+            .send(data.userTest.expectedDataForLogin)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('data');
+                done();
+            });
+    });
+
+    // for signin with wrong data
+    it('Should return an error with status code 400 and message', (done) => {
+        chai.request(server)
+            .post('/api/v1/auth/signin')
+            .set('Accept', 'Application/json')
+            .send(data.userTest.wrongDataForLogin)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(400);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+
+    // for signin with wrong data
+    it('Should return an object with status code 400 and an object which contains token and user data', (done) => {
+        chai.request(server)
+            .post('/api/v1/auth/signin')
+            .set('Accept', 'Application/json')
+            .send(data.userTest.loginNoEmail)
+            .end((err, res) => {
+                if (err) done(err);
+                expect(res).to.have.status(400);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('status');
+                expect(res.body).to.have.property('error');
+                done();
+            });
+    });
+});


### PR DESCRIPTION
#### What does this PR ​ do​ ?
As an admin I should be able to get all users announcements

#### Description of Task to be completed?
  * Add unit test for this api
  * Add a function to retrieve all uses' announcements,
 * In the above function to check wether a current user is an admin or not

#### How should this be manually tested?
* Clone this repository in case you don't have it using this command `git clone https://github.com/descholar-ceo/AnnounceIT.git`
* Type these commands : 
    *  `cd AnnounceIT` to go in the root directory of the project
    * `npm install` to install all the packages
    * `touch .env` to create dotenv file which will keep privately sensitive data for you,
    * Open the dotenv created above and copy paste this `PORT=8080` press Enter and copy paste 
     this `TOKEN_KEY=descholar` __you can always modify this data by changing the values of 
     PORT and TOKEN_KEY as you wish,__
    * `npm start` to start the server, sothat the api will be up and running
    * Open [Postman](https://www.getpostman.com/) and
    create a get request to this url `http://localhost:8080/api/v1/announcements/admin-get-all-announcements-from-all-users` as you can see the result shows that you don't have any regiistered announcement yet, [Follow this link to know how to add new announcement](https://github.com/descholar-ceo/AnnounceIT/pull/20)
    * Once you are done with adding new announcement enter again `http://localhost:8080/api/v1/announcements/admin-get-all-announcements-from-all-users`,

#### Any background context you want to provide?
* Use [Postman](https://www.getpostman.com/), to test it or any other rest-api testing tools available to you

#### What are the relevant pivotal tracker stories?
[170865656](https://www.pivotaltracker.com/n/projects/2429498#)

#### Screenshots (​ if​ appropriate)

#### Questions:
No Question